### PR TITLE
remove unused turtlecoin-crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "request": "^2.88.0",
     "rn-nodeify": "^10.0.1",
     "stream-browserify": "^1.0.0",
-    "turtlecoin-crypto": "^0.0.3",
     "turtlecoin-wallet-backend": "https://github.com/turtlecoin/turtlecoin-wallet-backend-js",
     "url": "^0.10.3",
     "vm-browserify": "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7422,7 +7422,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turtlecoin-crypto@0.0.3, turtlecoin-crypto@^0.0.3:
+turtlecoin-crypto@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/turtlecoin-crypto/-/turtlecoin-crypto-0.0.3.tgz#c7f0ba7d17e9422142179137161ea45c524d7576"
   integrity sha512-NG/NhSTJ+bg6FH4k+DfWjrMAH5z6yrKs6sgTmHcbqSTzglc+7cbEfVqPR2zK3PXi2+qumg3XjqAZnbIBOR3x/Q==


### PR DESCRIPTION
Tested on **Ubuntu 18.04 LTS**
Android SDK version : 28.0.3
Java version: OpenJDK Runtime Environment (build 1.8.0_152-release-1343-b16-5323222)
```
$ node --version
v10.15.3
$ npm --version
6.4.1
$ react-native --version
react-native-cli: 2.0.1
react-native: 0.57.8
$ yarn --version
1.15.2
```